### PR TITLE
Add  more options for multipole reference point + speed up 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+
+## 0.3.0-dev
+
+### New Features
+- Added support for non-water molecules by calculating the dipole moment per residue. This currently has some performance issues.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A python package containing an MDAnalysis class to calculate charge, dipolar and quadrupolar density profiles from simulation trajectories. 
 Also includes scripts (in the bin folder) to use this class from the command line and a class for calculating per molecule electrostatic properties.
 
-If you use this package, please link to this page, cite our paper (Chapman and Bresme 2022, unpublished) and [cite the papers](https://www.mdanalysis.org/pages/citations/) of the MDAnalaysis authors
+If you use this package, please link to this page, cite our paper (Chapman and Bresme 2022, PCCP) and [cite the papers](https://www.mdanalysis.org/pages/citations/) of the MDAnalaysis authors
 
 ## Requirements and Dependencies
 

--- a/bin/calc_multipoles_dens
+++ b/bin/calc_multipoles_dens
@@ -155,7 +155,7 @@ if __name__ == "__main__":
 
     traj_prep = TrajectoryPreparer(parser, models=pc_objs)
     # checking if the coords in last step need to be unwrapped:
-    traj_prep.wrap_check()  # TODO Remove, only unwrap arg now passed directly to multipole_dens
+    traj_prep.wrap_check()  # TODO: Remove, only unwrap arg now passed directly to multipole_dens
     traj_prep.rewind_traj()
     u = traj_prep.u
 
@@ -165,11 +165,14 @@ if __name__ == "__main__":
     # else:
     #     types_or_names = Multipoles.check_types_or_names(u)
     # verify if charges are present or not.
+
     try:
         u.atoms.charges  # type: ignore - Because no type annotations `pyright` thinks this is `None`
         charges_defined = True
     except mda.NoDataError:
         charges_defined = False
+    if args.verbose and args.calculate_dummy:
+        print("Calculating dummy atom positions on the fly!")
 
     # Set up the multipoles object
     multip = Multipoles(

--- a/bin/calc_multipoles_dens
+++ b/bin/calc_multipoles_dens
@@ -131,6 +131,13 @@ def set_up_parser():
         help="Distance from the oxygen along the dipole moment to use as the reference "
         "point for the multipole calculations.",
     )
+    parser.add_argument(
+        "-p",
+        "--plot",
+        default=False,
+        action="store_true",
+        help="If this flag is set, the total potential will be shown to the screen.",
+    )
 
     return parser
 
@@ -275,7 +282,10 @@ if __name__ == "__main__":
     ax_phi.axhline(0, color="grey", linestyle="--")
 
     plt.savefig("potential_and_field_plots.png")
-    plt.show()
+    if args.plot:
+        plt.show()
+    else:
+        plt.close()
 
     plt.plot(z, multip.results.cos_theta, label=r"$\langle \cos(\theta)\rangle$")
     plt.plot(

--- a/bin/calc_multipoles_dens
+++ b/bin/calc_multipoles_dens
@@ -36,6 +36,16 @@ def set_up_parser():
         choices=["water", "residue"],
         help="Specify how to determine molecules. If water, uses the M type and H type arguments to find the atoms and assumes molecules have contiguous ids. If 'residue' the molecules are found with the residue/molecule ids and the COM is used as the origin for the dipole calculation. ",
     )
+    # TODO: have this be inferred from the
+    parser.add_argument(
+        "--centre-method",
+        type=str,
+        choices=["com", "atom"],
+        default=None,
+        help="Where to put the location of the reference, for grouping='residue',"
+        "either on the COM or an atom specified with the `-M` flag",
+    )
+
     parser.add_argument(
         "-m",
         "--inmem",
@@ -169,6 +179,7 @@ if __name__ == "__main__":
         H_types=args.H_name,
         binsize=args.bin_width,
         calculate_dummy=args.calculate_dummy,
+        centre_method=args.centre_method,
         unwrap=args.unwrap,
         grouping=args.grouping,
         origin_dist=args.origin_dist,

--- a/bin/calc_multipoles_dens
+++ b/bin/calc_multipoles_dens
@@ -114,6 +114,14 @@ def set_up_parser():
         "or name. By default tries to work it out from the topology file.",
     )
 
+    parser.add_argument(
+        "--origin-dist",
+        default=0.0,
+        type=float,
+        help="Distance from the oxygen along the dipole moment to use as the reference "
+        "point for the multipole calculations.",
+    )
+
     return parser
 
 
@@ -163,6 +171,7 @@ if __name__ == "__main__":
         calculate_dummy=args.calculate_dummy,
         unwrap=args.unwrap,
         grouping=args.grouping,
+        origin_dist=args.origin_dist,
     )
 
     # Run the calculation

--- a/multipole/multipole_dens.py
+++ b/multipole/multipole_dens.py
@@ -659,7 +659,8 @@ def _find_res_splits(res_ids: NDArray, n_res: int) -> NDArray:
             current_res_type = r
             stack_top += 1
 
-    res_splits[n_res - 1] = n_res
+    n_atoms = len(res_ids)
+    res_splits[n_res - 1] = n_atoms
 
     return res_splits
 

--- a/multipole/multipole_dens.py
+++ b/multipole/multipole_dens.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import enum
 from .point_charge_water import PCParams, pc_parameters
 
-from typing import Dict, List, Never, Optional, Union, assert_never
+from typing import Dict, List, Optional, Union
 import warnings
 
 import numpy as np
@@ -577,11 +577,11 @@ class Multipoles(AnalysisBase):
         mu - eAA/AA^3 -> C/AA^2
         Q - eAA^2/AA^3 -> C/AA
         rho_q - e/AA^3 -> C/AA^3
-        TODO: Add option to keep in e/AA^N
 
         NOTE:
         Results are saved by normalising cumulative sums of the properties.
         """
+        # TODO: Add option to keep units in e/AA^N
 
         # Average results over the  number of configurations
 

--- a/multipole/multipole_dens.py
+++ b/multipole/multipole_dens.py
@@ -692,7 +692,7 @@ def calculate_Q_ag(positions: NDArray, charges: NDArray, origin: NDArray) -> NDA
             for k in range(3):
                 result[j, k] += q * p[j] * p[k]
 
-    return result
+    return 0.5 * result
 
 
 def check_types_or_names(universe: mda.Universe) -> str:

--- a/multipole/multipole_dens.py
+++ b/multipole/multipole_dens.py
@@ -6,13 +6,11 @@ from typing import Dict, List, Optional, Union
 import warnings
 
 import numpy as np
-import numpy.linalg as la
 from numpy.typing import NDArray
 import MDAnalysis as mda
 from MDAnalysis.analysis.base import AnalysisBase, Results
 from scipy.constants import elementary_charge
 from numba import jit
-from numba import float32
 from fast_histogram import histogram1d
 
 
@@ -888,7 +886,6 @@ def get_dummy_position(xO: NDArray, xH1: NDArray, xH2: NDArray, dM: float) -> ND
     return xO + dM * dxM
 
 
-# TODO: These type annotations don't seem to work when called
 @jit(nopython=True)
 def _unwrap_water_coords(rO, rH1, rH2, box):
     """

--- a/multipole/point_charge_water.py
+++ b/multipole/point_charge_water.py
@@ -171,6 +171,9 @@ pc_parameters: Dict[str, PCParams] = {
     ),
     "spce": PCParams.from_dict({"q": 0.4238, "r": 1.0000, "theta": 109.47, "r_M": 0}),
     "tip3p": PCParams.from_dict({"q": 0.417, "r": 0.9572, "theta": 104.52, "r_M": 0}),
+    "opc3": PCParams.from_dict(
+        {"q": 0.447585, "r": 0.97888, "theta": 109.47, "r_M": 0}
+    ),
 }
 
 

--- a/multipole/trajectory_prepare.py
+++ b/multipole/trajectory_prepare.py
@@ -4,7 +4,7 @@ import MDAnalysis as mda
 
 import argparse
 
-from .multipole_dens import check_types_or_names
+from .multipole_dens import _check_types_or_names
 import MDAnalysis.transformations
 
 
@@ -19,6 +19,7 @@ class TrajectoryPreparer:
         args_parser: argparse.ArgumentParser,
         models: Union[Dict[str, PointChargeModel], None] = None,
     ):
+        # FIXME: This *REALLY* should just have the arguments parsed into it.
         args = args_parser.parse_args()
         self.args = args
 
@@ -45,7 +46,7 @@ class TrajectoryPreparer:
         if self.args.types_or_names:
             self.types_or_names = self.args.types_or_names
         else:
-            self.types_or_names = check_types_or_names(self.u)
+            self.types_or_names = _check_types_or_names(self.u)
 
         self.H_name = self.args.H_name
         self.M_name = self.args.M_name


### PR DESCRIPTION
## Changes
This PR adds two new options:

- `origin-dist` : For `grouping="water"` this sets the distance along the dipole moment vector to displace the reference point away from the oxygen atom location.
This option has no effect for `grouping="residue"`
- `centre-method`: for `grouping="residue"` this can be either `atom` or `com` (default). 
If the former, the reference point is placed on the location of the atom specified with `-M`. Otherwise, it is placed on the location of the centre of mass.

This PR also drastically improves the speed of `grouping='residue'`.
This comes at the cost of the breaking change that the atoms of a given residue (molecule) must all be consecutive in the trajectory --- this is usually the case, especially for small molecule systems.

## BREAKING CHANGES:
- The atoms of a given residue (molecule) must all be consecutive in the trajectory
- Plots are no longer automatically shown to the screen, but will be saved.
They can still be shown with the `-p` flag.
